### PR TITLE
Add shingle by default in likeanalyzer. Better error message when the…

### DIFF
--- a/qwazr-search/src/main/java/com/qwazr/search/analysis/LikeAnalyzer.java
+++ b/qwazr-search/src/main/java/com/qwazr/search/analysis/LikeAnalyzer.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Emmanuel Keller / QWAZR
- * <p>
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,10 +15,12 @@
  */
 package com.qwazr.search.analysis;
 
+import com.qwazr.utils.StringUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter;
+import org.apache.lucene.analysis.shingle.ShingleFilter;
 import org.apache.lucene.analysis.standard.StandardFilter;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 
@@ -34,7 +36,10 @@ final public class LikeAnalyzer extends Analyzer {
 		tok.setMaxTokenLength(MAX_TOKEN_LENGTH);
 		TokenStream result = new StandardFilter((TokenStream) tok);
 		result = new LowerCaseFilter(result);
-		result = new ASCIIFoldingFilter(result, true);
+		result = new ASCIIFoldingFilter(result, false);
+		ShingleFilter sf = new ShingleFilter(result);
+		sf.setTokenSeparator(StringUtils.EMPTY);
+		result = sf;
 		return new TokenStreamComponents(tok, result) {
 			protected void setReader(Reader reader) throws IOException {
 				tok.setMaxTokenLength(MAX_TOKEN_LENGTH);

--- a/qwazr-webapps/src/main/java/com/qwazr/webapps/transaction/FileClassCompilerLoader.java
+++ b/qwazr-webapps/src/main/java/com/qwazr/webapps/transaction/FileClassCompilerLoader.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2014-2015 Emmanuel Keller / QWAZR
- * <p>
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -121,6 +121,8 @@ public class FileClassCompilerLoader implements Closeable, AutoCloseable {
 	private void compile(File sourceFile) throws IOException {
 		DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		if (compiler == null)
+			throw new IOException("No compiler is available. This feature requires a JDK (not a JRE).");
 		StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null, null);
 		try {
 			Iterable<? extends JavaFileObject> sourceFiles = fileManager.getJavaFileObjects(sourceFile);


### PR DESCRIPTION
… java compiler is not presend.