### PR TITLE
The log4j.properties file was copied in the wrong directory (/var/lib…

### DIFF
--- a/qwazr-server/pom.xml
+++ b/qwazr-server/pom.xml
@@ -237,7 +237,7 @@
                                     <conffile>true</conffile>
                                     <mapper>
                                         <type>perm</type>
-                                        <prefix>/var/lib/${project.artifactId}</prefix>
+                                        <prefix>/var/lib/qwazr</prefix>
                                     </mapper>
                                 </data>
                             </dataSet>


### PR DESCRIPTION
…/qwazr-server). Should be /var/lib/qwazr #214